### PR TITLE
Connect question list and question page with link

### DIFF
--- a/app/assets/stylesheets/question.css.scss
+++ b/app/assets/stylesheets/question.css.scss
@@ -77,6 +77,15 @@ $formExceptTextareaHeight: ($formTitleHeight+$formTagHeight+$formDescriptionHeig
             height: 33%;
             overflow: hidden;
             font-size: $questionListTitle;
+            a {
+              color: #444;
+              height: 100%;
+              display: block;
+              text-decoration: none;
+              &:hover {
+                color: $accentGreenColor;
+              }
+            }
           }
 
           .question-description {

--- a/app/assets/stylesheets/question.css.scss
+++ b/app/assets/stylesheets/question.css.scss
@@ -93,10 +93,17 @@ $formExceptTextareaHeight: ($formTitleHeight+$formTagHeight+$formDescriptionHeig
             overflow: hidden;
             font-size: $questionListDescription;
 
-            span {
+            a {
               display: -webkit-box;
               -webkit-box-orient: vertical;
               -webkit-line-clamp: 2;
+              color: #444;
+              height: 100%;
+              display: block;
+              text-decoration: none;
+              &:hover {
+                color: $accentGreenColor;
+              }
             }
           }
 

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -9,7 +9,7 @@ li.questions-list.box-sizing.row
       = link_to question.title, question_path(question)
     .question-description
       span
-        = question.description
+        = link_to question.description, question_path(question)
     ul.question-tags.clearfix
       - question.tags.each do |tag|
         li.question-tags-list.box-sizing

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -6,7 +6,7 @@ li.questions-list.box-sizing.row
     = image_tag 'http://kinocode.jp/new/wp-content/uploads/2015/10/950805bc8a944944bdef670a2b591238.png'
   .question-context.box-sizing.col-md-6.col-sm-5.col-xs-8
     h3.question-title
-      = question.title
+      = link_to question.title, question_path(question)
     .question-description
       span
         = question.description


### PR DESCRIPTION
# what

問題の一覧表示ページにある、問題のタイトルや説明からモンdないの詳細ページにリンクするようにした
